### PR TITLE
chore(config): remove Rollbar access token

### DIFF
--- a/src/config/config.dev.json
+++ b/src/config/config.dev.json
@@ -2,8 +2,8 @@
     "instrumentation": {
       "environment": "local-dev",
       "rollbar": {
-        "enabled": true,
-        "accessToken": "c01694ee3b104c5a93ee2eef1e1a085e"
+        "enabled": false,
+        "accessToken": ""
       }
     }
 }


### PR DESCRIPTION
I accidentally pushed the Rollbar token to the repo. I've removed it from the config file and deleted the token in Rollbar and generated a new one.